### PR TITLE
Dismiss animation fix

### DIFF
--- a/CDRTranslucentSideBar/CDRTranslucentSideBar/CDRTranslucentSideBar.m
+++ b/CDRTranslucentSideBar/CDRTranslucentSideBar/CDRTranslucentSideBar.m
@@ -350,7 +350,7 @@
 	if (animated) {
 		CGRect sideBarFrame = self.translucentView.frame;
 		CGFloat parentWidth = self.view.bounds.size.width;
-		sideBarFrame.origin.x = self.showFromRight ? parentWidth : -self.sideBarWidth + deltaXFromStartXToEndX;
+		sideBarFrame.origin.x = self.showFromRight ? parentWidth : -self.sideBarWidth;
 
 		[UIView animateWithDuration:self.animationDuration
 		                      delay:0


### PR DESCRIPTION
`- (void)dismissAnimated:(BOOL)animated deltaX:(CGFloat)deltaXFromStartXToEndX` doesn't calculate final frame for sidebar animation correctly, when the sidebar is on the left.

It happens when the user opens sidebar using a pan gesture, but doesn't drag it far enough, so sidebar is dismissed. In this case `deltaXFromStartXToEndX ` is equal to a distance the sidebar has been dragged right. So, this line:
    
    sideBarFrame.origin.x = self.showFromRight ? parentWidth : -self.sideBarWidth + deltaXFromStartXToEndX;
doesn't really calculate a final position for a hidden sidebar (which it should, I believe), but instead calculates the current position of a sidebar (initial position + offset due to pan gesture). 

NSLog here:

    if (self.contentView != nil) {
        self.contentView.frame = sideBarFrame;
    }
shows that `self.contentView.frame` and `sideBarFrame` have the same value already. So animation is not performed (there is nothing to animate), and sidebar just disappears without it (with help of a completion block), which looks bad.

GIF animations to demonstrate the problem:

# Without fix:
![without_fix](https://cloud.githubusercontent.com/assets/11556297/6927945/29f4b662-d80a-11e4-9f01-9f7a5355d23b.gif)
# With fix:
![with_fix](https://cloud.githubusercontent.com/assets/11556297/6927946/2d859454-d80a-11e4-892b-9e5d5e08ad28.gif)

P.S. Sorry for my English and sorry if I made some mistakes creating this pull request. I'm new to open source :) Thank you for your control, it is great!